### PR TITLE
fix: update traefik-proxy chart docs and version

### DIFF
--- a/charts/traefik-proxy/Chart.yaml
+++ b/charts/traefik-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: traefik-proxy
 type: application
-version: 1.0.1
+version: 1.0.2
 icon: https://raw.githubusercontent.com/SwanHubX/charts/main/assets/icon.png
 description: A Helm chart app encapsulating most of the Traefik resource configurations.
 home: https://swanlab.cn

--- a/charts/traefik-proxy/README.md
+++ b/charts/traefik-proxy/README.md
@@ -22,4 +22,14 @@ spec:
       AuthUrl: "http://swanlab-server:3000/api/identity"
 ```
 
-Note: by default, ingressClass is set to `traefik-proxy`, and isDefaultClass is set to `false`. You may need to adjust these values based on your cluster configuration.
+For flexibility, we have not predefined a schema for traefik-proxy.
+If you have some understanding of [traefik](https://helm.traefik.io/traefik), you can freely configure the relevant parameter values under the `traefik` property. 
+Otherwise, we recommend using the `traefik` helm directly, as it is more versatile:
+
+```bash
+helm repo add traefik https://helm.traefik.io/traefik
+
+helm install traefik traefik/traefik
+```
+
+> Note: by default, [providers.kubernetesCRD.labelSelector](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-crd/#opt-providers-kubernetesCRD-labelselector) is set to `swanlab=traefik-proxy`. You may need to adjust these values based on your cluster configuration.

--- a/charts/traefik-proxy/values.yaml
+++ b/charts/traefik-proxy/values.yaml
@@ -94,5 +94,5 @@ traefik:
     kubernetesCRD:
       # Label selector to filter IngressRoute resources
       # It's useful when multiple applications deploy Traefik in the same cluster.
-      # Only supports a single selector in the current version:
+      # Only supports a single selector in the current version, and you may need recreate Traefik release to change it.
       labelSelector: "swanlab=traefik-proxy"


### PR DESCRIPTION
Bumped chart version to 1.0.2. Improved README with guidance on configuring traefik-proxy and recommended using the official traefik Helm chart for advanced use cases. Clarified labelSelector usage in values.yaml.