### PR TITLE
Bump chart and app versions to 0.2.0 and 2.6.0

### DIFF
--- a/charts/self-hosted/Chart.yaml
+++ b/charts/self-hosted/Chart.yaml
@@ -5,8 +5,8 @@ description: A Helm chart for deploying SwanLab, an open-source ML experiment tr
 icon: https://raw.githubusercontent.com/SwanHubX/charts/main/assets/icon.png
 home: https://swanlab.cn
 type: application
-version: 0.1.5
-appVersion: 2.5.0
+version: 0.2.0
+appVersion: 2.6.0
 keywords:
   - swanlab
   - ml-ops


### PR DESCRIPTION
正式版0.2.0
镜像版本升级至2.6.0