### PR TITLE
fix: remove Chart.lock from self-hosted Helm chart

### DIFF
--- a/charts/self-hosted/Chart.lock
+++ b/charts/self-hosted/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: traefik-proxy
-  repository: https://helm.swanlab.cn
-  version: 1.0.2
-digest: sha256:094d979aa714c87a28502022253e69b553257ebee9a69a96eea12deb742fdf8a
-generated: "2025-11-26T14:18:37.630889+08:00"


### PR DESCRIPTION
Deleted the Chart.lock file from charts/self-hosted, possibly to update dependencies or resolve lock file issues.