### PR TITLE
chore: unset image tag for swanlab-cloud service

### DIFF
--- a/charts/self-hosted/Chart.yaml
+++ b/charts/self-hosted/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for deploying SwanLab, an open-source ML experiment tr
 icon: https://raw.githubusercontent.com/SwanHubX/charts/main/assets/icon.png
 home: https://swanlab.cn
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 2.6.4
 keywords:
   - swanlab

--- a/charts/self-hosted/values.yaml
+++ b/charts/self-hosted/values.yaml
@@ -113,7 +113,7 @@ service:
     image:
       repository: repo.swanlab.cn/self-hosted/swanlab-cloud
       # For patch update delivery
-      tag: "v2.6.3"
+      tag: ""
       pullPolicy: "IfNotPresent"
 
 


### PR DESCRIPTION
更新swanlab-cloud至2.6.4