### PR TITLE
fix(ci): trust cm-push output for ACR push success detection

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -86,15 +86,13 @@ jobs:
             --password "$HELM_REPO_PASSWORD"
           CM_PUSH="$(helm env HELM_PLUGINS)/helm-acr/bin/helm-cm-push"
           helm repo update acr-swanlab
-          if helm search repo "acr-swanlab/self-hosted" --version "$CHART_VERSION" | grep -q "self-hosted"; then
-            echo "[ACR] Chart self-hosted:$CHART_VERSION already exists, skipping push"
+          # cm-push 无可靠 exit code，以输出中出现 "Done" 作为推送成功标志
+          CM_PUSH_OUTPUT=$("$CM_PUSH" ./charts/self-hosted acr-swanlab 2>&1) || true
+          echo "$CM_PUSH_OUTPUT"
+          if echo "$CM_PUSH_OUTPUT" | grep -q "Done"; then
+            ACR_PUSHED="true"
           else
-            "$CM_PUSH" ./charts/self-hosted acr-swanlab
-            # cm-push 无可靠 exit code，push 后重新 search 复查此次推送是否生效
-            helm repo update acr-swanlab
-            if helm search repo "acr-swanlab/self-hosted" --version "$CHART_VERSION" | grep -q "self-hosted"; then
-              ACR_PUSHED="true"
-            fi
+            echo "[ACR] Push did not confirm success (no 'Done' in output)"
           fi
 
           # --- Push via OCI ---


### PR DESCRIPTION
## 问题

合并 v0.5.0 (`#52`) 后，飞书 webhook 通知步骤被跳过，未发送。

通过 `gh cli` 分析 run `28350783821`：
- Step 10「📢 Notify Feishu on New Release」状态为 `skipped`
- 即 `if: steps.push_acr.outputs.acr_pushed == 'true' && steps.push_acr.outputs.oci_pushed == 'true'` 求值为 false
- 但日志显示两路推送其实都成功了：
  - ACR: `Pushing self-hosted-0.5.0.tgz to acr-swanlab... Done.`
  - OCI: `Pushed: .../self-hosted:0.5.0`

## 根因

`push_acr` 步对 ACR 推送是否成功的判断不依赖 `cm-push` 本身，而是 push 后再做一次 `helm search repo "acr-swanlab/self-hosted" --version "$CHART_VERSION"` 复查（脚本注释里也承认 "cm-push 无可靠 exit code"）。

ACR 仓库索引对刚 push 的版本有最终一致性延迟，第二次 search 没命中 → `grep -q "self-hosted"` 失败 → `ACR_PUSHED` 保持初始值 `"false"` → `if` 条件不成立 → Notify 被跳过。

注：v0.5.0 run 是 Notify 步引入后的首次运行，之前 run 的 workflow 里根本没有这一步。

## 修复

去掉 `--version` 约束与 push 后的 search 复查，直接信任 `cm-push` 的输出：以出现 `Done` 作为推送成功标志，`ACR_PUSHED=true`。

OCI 部分保持不变（already exists 时仍跳过通知，属合理幂等行为）。

## 验证

下次有新 chart 版本推送时，ACR 只要 `cm-push` 输出 `Done.`，`acr_pushed=true` 即成立，飞书通知会触发。
