### PR TITLE
chore: bump chart to 0.5.1, add maxMetricsPerCopy limit config and fix gateway field placement

### DIFF
--- a/charts/self-hosted/Chart.yaml
+++ b/charts/self-hosted/Chart.yaml
@@ -5,8 +5,8 @@ description: A Helm chart for deploying SwanLab, an open-source ML experiment tr
 icon: https://raw.githubusercontent.com/SwanHubX/charts/main/assets/icon.png
 home: https://swanlab.cn
 type: application
-version: 0.5.0
-appVersion: "2.9.0"
+version: 0.5.1
+appVersion: "2.9.1"
 keywords:
   - swanlab
   - ml-ops

--- a/charts/self-hosted/templates/swanlab-server/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-server/deployment.yaml
@@ -144,6 +144,11 @@ spec:
               value: "/api"
             - name: SS_HOUSE_URL
               value: "http://{{ include "swanlab.house.fullname" . }}:{{ include "swanlab.house.port" . }}/api/house"
+            - name: SS_EXPERIMENT_MAX_COLUMNS
+              value: {{ .Values.global.settings.limits.maxMetricsPerCopy | quote }}
+            - name: SS_EXPERIMENT_MAX_CHARTS
+              value: {{ .Values.global.settings.limits.maxChartsPerCopy | quote }}
+
             # s3
             - name: SS_STORAGE_TYPE
               value: {{ include "swanlab.s3.type" . | quote }}

--- a/charts/self-hosted/values.schema.json
+++ b/charts/self-hosted/values.schema.json
@@ -25,7 +25,13 @@
         "settings": {
           "type": "object",
           "properties": {
-            "host": { "type": "string" }
+            "host": { "type": "string" },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "maxMetricsPerCopy": { "type": "integer", "minimum": 20000 }
+              }
+            }
           }
         }
       }
@@ -44,15 +50,32 @@
         "customPodAnnotations": { "type": "object" },
         "customTolerations": { "type": "array" },
         "customNodeSelector": { "type": "object" },
-        "service": {"type": "object", "properties": {
-          "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
-          "ports": { "type": "object", "properties": {
-            "web": { "type": "integer", "minimum": 1, "maximum": 65535 },
-            "internal": { "type": "integer", "minimum": 1, "maximum": 65535 },
-            "traefik": { "type": "integer", "minimum": 1, "maximum": 65535 },
-            "metrics": { "type": "integer", "minimum": 1, "maximum": 65535 }
-          }}
-        }},
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+            },
+            "ports": {
+              "type": "object",
+              "properties": {
+                "web": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "internal": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "traefik": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "metrics": { "type": "integer", "minimum": 1, "maximum": 65535 }
+              }
+            }
+          }
+        },
         "resources": { "$ref": "#/definitions/resources" }
       }
     },
@@ -314,7 +337,15 @@
         "bucket": { "type": "string" },
         "domain": { "type": "string", "format": "uri-reference" }
       },
-      "required": ["bucket", "endpoint", "region", "port", "pathStyle", "ssl", "domain"]
+      "required": [
+        "bucket",
+        "endpoint",
+        "region",
+        "port",
+        "pathStyle",
+        "ssl",
+        "domain"
+      ]
     }
   }
 }

--- a/charts/self-hosted/values.yaml
+++ b/charts/self-hosted/values.yaml
@@ -18,6 +18,14 @@ global:
     # If you use SSO features, this is recommended to be set to the external URL of your gateway (e.g., https://app.example.com).
     host: ""
 
+    # Global resource limits (apply across all modules)
+    # These are safety guardrails to prevent excessive resource usage
+    limits:
+      # Maximum number of metrics/charts allowed per single copy operation
+      maxMetricsPerCopy: 20000
+
+
+
 gateway:
   fullnameOverride: ""
 
@@ -119,14 +127,6 @@ service:
       # For patch update delivery
       tag: ""
       pullPolicy: "IfNotPresent"
-
-    customLabels: {}
-    customAnnotations: {}
-    customPodLabels: {}
-    customPodAnnotations: {}
-    customTolerations: []
-    customNodeSelector: {}
-    resources: {}
 
   # Configuration of our data collection services
   house:


### PR DESCRIPTION
## Summary

本次变更将 Chart 版本从 0.5.0 升级至 0.5.1，同步 appVersion 至 2.9.1，并引入新的指标复制限制配置。

## Changes

- **新增** `global.settings.limits.maxMetricsPerCopy` 配置项，用于限制单次复制操作的最大指标/图表数量（默认 20000），对应的 values 默认值和 JSON Schema 验证规则同步添加
- **版本** Chart version 0.5.0 → 0.5.1，appVersion 2.9.0 → 2.9.1

## Testing

未运行测试。

## Notes

- `maxMetricsPerCopy` 最低值限制为 20000，设置为更低值将触发 schema 校验失败