### PR TITLE
feat: add experiment resource limit configuration

### DIFF
--- a/charts/self-hosted/Chart.yaml
+++ b/charts/self-hosted/Chart.yaml
@@ -5,8 +5,8 @@ description: A Helm chart for deploying SwanLab, an open-source ML experiment tr
 icon: https://raw.githubusercontent.com/SwanHubX/charts/main/assets/icon.png
 home: https://swanlab.cn
 type: application
-version: 0.5.0
-appVersion: "2.9.0"
+version: 0.5.1
+appVersion: "2.9.1"
 keywords:
   - swanlab
   - ml-ops

--- a/charts/self-hosted/templates/swanlab-server/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-server/deployment.yaml
@@ -147,7 +147,7 @@ spec:
             - name: SS_EXPERIMENT_MAX_COLUMNS
               value: {{ .Values.global.settings.limits.maxMetricsPerCopy | quote }}
             - name: SS_EXPERIMENT_MAX_CHARTS
-              value: {{ .Values.global.settings.limits.maxChartsPerCopy | quote }}
+              value: {{ .Values.global.settings.limits.maxMetricsPerCopy | quote }}
 
             # s3
             - name: SS_STORAGE_TYPE

--- a/charts/self-hosted/templates/swanlab-server/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-server/deployment.yaml
@@ -144,6 +144,11 @@ spec:
               value: "/api"
             - name: SS_HOUSE_URL
               value: "http://{{ include "swanlab.house.fullname" . }}:{{ include "swanlab.house.port" . }}/api/house"
+            - name: SS_EXPERIMENT_MAX_COLUMNS
+              value: {{ .Values.global.settings.limits.maxMetricsPerCopy | quote }}
+            - name: SS_EXPERIMENT_MAX_CHARTS
+              value: {{ .Values.global.settings.limits.maxChartsPerCopy | quote }}
+
             # s3
             - name: SS_STORAGE_TYPE
               value: {{ include "swanlab.s3.type" . | quote }}

--- a/charts/self-hosted/values.schema.json
+++ b/charts/self-hosted/values.schema.json
@@ -25,7 +25,13 @@
         "settings": {
           "type": "object",
           "properties": {
-            "host": { "type": "string" }
+            "host": { "type": "string" },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "maxMetricsPerCopy": { "type": "integer", "minimum": 20000 }
+              }
+            }
           }
         }
       }
@@ -44,15 +50,32 @@
         "customPodAnnotations": { "type": "object" },
         "customTolerations": { "type": "array" },
         "customNodeSelector": { "type": "object" },
-        "service": {"type": "object", "properties": {
-          "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
-          "ports": { "type": "object", "properties": {
-            "web": { "type": "integer", "minimum": 1, "maximum": 65535 },
-            "internal": { "type": "integer", "minimum": 1, "maximum": 65535 },
-            "traefik": { "type": "integer", "minimum": 1, "maximum": 65535 },
-            "metrics": { "type": "integer", "minimum": 1, "maximum": 65535 }
-          }}
-        }},
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+            },
+            "ports": {
+              "type": "object",
+              "properties": {
+                "web": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "internal": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "traefik": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "metrics": { "type": "integer", "minimum": 1, "maximum": 65535 }
+              }
+            }
+          }
+        },
         "resources": { "$ref": "#/definitions/resources" }
       }
     },
@@ -314,7 +337,15 @@
         "bucket": { "type": "string" },
         "domain": { "type": "string", "format": "uri-reference" }
       },
-      "required": ["bucket", "endpoint", "region", "port", "pathStyle", "ssl", "domain"]
+      "required": [
+        "bucket",
+        "endpoint",
+        "region",
+        "port",
+        "pathStyle",
+        "ssl",
+        "domain"
+      ]
     }
   }
 }

--- a/charts/self-hosted/values.yaml
+++ b/charts/self-hosted/values.yaml
@@ -18,6 +18,12 @@ global:
     # If you use SSO features, this is recommended to be set to the external URL of your gateway (e.g., https://app.example.com).
     host: ""
 
+    # Global resource limits (apply across all modules)
+    # These are safety guardrails to prevent excessive resource usage
+    limits:
+      # Maximum number of metrics/charts allowed per single copy operation
+      maxMetricsPerCopy: 20000
+
 gateway:
   fullnameOverride: ""
 


### PR DESCRIPTION
## Summary

为 self-hosted Helm Chart 添加实验复制操作的资源限制配置，并将限制值注入到 swanlab-server 环境变量中。

## Changes

- 在 `values.yaml` 中新增 `global.settings.limits.maxMetricsPerCopy`，默认值为 `20000`。
- 在 `values.schema.json` 中新增 `maxMetricsPerCopy` 的类型与最小值校验。
- 在 swanlab-server Deployment 中新增 `SS_EXPERIMENT_MAX_COLUMNS` 和 `SS_EXPERIMENT_MAX_CHARTS` 环境变量，统一使用 `maxMetricsPerCopy` 配置值。
- 补齐 `deployment.yaml` 文件末尾换行。

## Testing

- 已运行：`helm lint charts/self-hosted`
- 已运行：`helm template self-hosted charts/self-hosted >/tmp/self-hosted-rendered.yaml`

## Notes

- 当前配置使用单一 `maxMetricsPerCopy` 值同时控制 metrics 和 charts 的复制上限。
- 该变更依赖 swanlab-server 识别 `SS_EXPERIMENT_MAX_COLUMNS` 与 `SS_EXPERIMENT_MAX_CHARTS` 环境变量。