### PR TITLE
chore: bump traefik-proxy init container images to v2.0

### DIFF
--- a/charts/traefik-proxy/Chart.yaml
+++ b/charts/traefik-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: traefik-proxy
 type: application
-version: 1.1.2
+version: 1.2.0
 icon: https://raw.githubusercontent.com/SwanHubX/charts/main/assets/icon.png
 description: A Helm chart app encapsulating most of the Traefik resource configurations.
 home: https://swanlab.cn

--- a/charts/traefik-proxy/values.yaml
+++ b/charts/traefik-proxy/values.yaml
@@ -75,7 +75,7 @@ traefik:
     initContainers:
       - name: download-identify
         # Image for the init container that downloads the custom plugin files
-        image: repo.swanlab.cn/public/swanlab-helper/identify:v1.3
+        image: repo.swanlab.cn/public/swanlab-helper/identify:v2.0
         env:
           - name: COPY_TO
             value: /plugins-tmp/identify
@@ -85,7 +85,7 @@ traefik:
             mountPath: /plugins-tmp
       - name: download-robots
         # Image for the init container that downloads the custom plugin files
-        image: repo.swanlab.cn/public/swanlab-helper/robots:v1.0
+        image: repo.swanlab.cn/public/swanlab-helper/robots:v2.0
         env:
           - name: COPY_TO
             value: /plugins-tmp/robots


### PR DESCRIPTION
## Summary

将 traefik-proxy chart 中两个 init container 镜像版本升级至 v2.0。

## Changes

- `charts/traefik-proxy/values.yaml`: `identify` init container 镜像 `v1.3` → `v2.0`
- `charts/traefik-proxy/values.yaml`: `robots` init container 镜像 `v1.0` → `v2.0`

## Testing

未运行测试。建议在测试集群中部署验证 init container 行为是否正常。

## Notes

- Chart 版本（`Chart.yaml` 中 `version: 1.1.2`）未同步升级，如需发版请补充 bump。
- `identify` 和 `robots` v2.0 镜像已在 5b1654e 对应的 swanlab-self-hosted 中同步更新。