### PR TITLE
chore: add security context upgrade

### DIFF
--- a/charts/self-hosted/templates/_helpers.tpl
+++ b/charts/self-hosted/templates/_helpers.tpl
@@ -82,11 +82,17 @@ Helper Image Pull Policy
 {{- end }}
 
 {{/*
-Pod-level security context.
-Generates a securityContext block for the pod spec based on the owning service's settings.
+Pod 级 securityContext，仅在所属服务 securityContext.enabled=true 时渲染。
 
-Usage: {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
-The uid and gid are used when the owning service's securityContext.enabled is true.
+Usage:
+  {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
+
+Params:
+  root                 - 根上下文。
+  securityContext      - 所属服务的 securityContext 配置。
+  uid / gid            - 镜像内服务用户的 uid/gid。
+  allowPrivilegedPorts - （可选）容器需以非 root 绑定特权端口（< 1024，
+                         如 traefik/nginx 的 80）时置 true。
 */}}
 {{- define "swanlab.podSecurityContext" -}}
 {{- $sc := .securityContext | default (dict "enabled" false) -}}
@@ -99,10 +105,8 @@ securityContext:
   fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault
-  {{- /* 容器需监听 <1024 特权端口时（如 traefik/nginx 的 80），降低本 pod 网络命名空间的
-       非特权端口起始值，使非 root 进程可直接绑定。相比 NET_BIND_SERVICE capability
-       更可靠：capability 在 containerd 运行时下经 shell entrypoint exec 后会丢失，
-       而 sysctl 是内核级检查，与运行时无关。要求节点内核 >= 4.11。 */ -}}
+  {{- /* 安全 sysctl：允许非 root 进程绑定 >= 80 的端口。优于 NET_BIND_SERVICE
+       capability（在 containerd 下经 shell entrypoint exec 后会丢失）。要求节点内核 >= 4.11。 */ -}}
   {{- if .allowPrivilegedPorts }}
   sysctls:
     - name: net.ipv4.ip_unprivileged_port_start
@@ -112,13 +116,16 @@ securityContext:
 {{- end -}}
 
 {{/*
-Container-level security context.
-Generates a securityContext block for a container spec.
+容器级 securityContext，仅在所属服务 securityContext.enabled=true 时渲染。
 
-Usage (no extra capabilities):
-  {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
-Usage (with extra capabilities, e.g., NET_BIND_SERVICE for ports < 1024):
-  {{- include "swanlab.containerSecurityContext" (dict "root" . "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
+Usage:
+  {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext) | nindent 10 }}
+  {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
+
+Params:
+  root            - 根上下文。
+  securityContext - 所属服务的 securityContext 配置。
+  addCaps         - （可选）drop ALL 之后需要加回的 capability。
 */}}
 {{- define "swanlab.containerSecurityContext" -}}
 {{- $sc := .securityContext | default (dict "enabled" false) -}}
@@ -137,22 +144,32 @@ securityContext:
 {{- end }}
 {{- end -}}
 
-
 {{/*
-Root initContainer that aligns data-volume ownership with the service user before
-startup. Rendered automatically when the owning service enables securityContext.
-Needed for volumes whose files are owned by root (e.g. data written before
-hardening), or clusters whose CSI fsGroupPolicy makes fsGroup ineffective.
-Incompatible with the restricted PodSecurityStandard (root initContainer).
+Root initContainer，在容器启动前将数据卷属主对齐为服务用户，仅在所属服务
+securityContext.enabled=true 时渲染。覆盖两类场景：卷内残留 root 属主文件
+（加固前写入），以及 CSI fsGroupPolicy 导致 fsGroup 失效的集群。因其以 root
+运行，与 restricted PodSecurityStandard 不兼容，此类集群请保持
+securityContext.enabled=false。
+
+逐文件检查、仅 chown 不匹配项，卷已对齐时只付出一次只读遍历。不能用"检查卷
+根目录属主"的短路替代：setgid 目录只把 group 遗传给新文件、不遗传 user，根
+目录属主正常不代表卷内没有此前 root pod 写入的 root 属主文件。
 
 Usage:
-  {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000 "volumeName" "<volume-name>" "mountPath" "/data") | trim) }}
+  {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000 "volumeName" "<volume-name>" "mountPath" "/data") | trim) }}
   initContainers:
     {{- . | nindent 8 }}
   {{- end }}
+
+Params:
+  root            - 根上下文（helper 镜像 / 拉取策略）。
+  securityContext - 所属服务的 securityContext 配置。
+  uid / gid       - 服务用户的 uid/gid。
+  volumeName      - 需要修正属主的数据卷。
+  mountPath       - 数据卷在 initContainer 内的挂载路径。
 */}}
 {{- define "swanlab.volumePermissionsInit" -}}
-{{- $sc := .sc | default (dict "enabled" false) -}}
+{{- $sc := .securityContext | default (dict "enabled" false) -}}
 {{- if $sc.enabled -}}
 - name: init-volume-permissions
   image: {{ include "swanlab.helperImage" .root }}
@@ -160,7 +177,7 @@ Usage:
   command: ["/bin/sh", "-c"]
   args:
     - |
-      find {{ .mountPath }} ! -user {{ .uid }} -exec chown -R {{ .uid }}:{{ .gid }} {} \;
+      find {{ .mountPath }} \( ! -user {{ .uid }} -o ! -group {{ .gid }} \) -exec chown {{ .uid }}:{{ .gid }} {} +
   securityContext:
     runAsUser: 0
     runAsNonRoot: false

--- a/charts/self-hosted/templates/_helpers.tpl
+++ b/charts/self-hosted/templates/_helpers.tpl
@@ -83,22 +83,20 @@ Helper Image Pull Policy
 
 {{/*
 Pod-level security context.
-Generates a securityContext block for the pod spec based on global.securityContext settings.
+Generates a securityContext block for the pod spec based on the owning service's settings.
 
-Usage: {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
-The uid and gid are used as runAsUser/runAsGroup/fsGroup when global.securityContext.runAsNonRoot is true.
+Usage: {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
+The uid and gid are used when the owning service's securityContext.enabled is true.
 */}}
 {{- define "swanlab.podSecurityContext" -}}
-{{- $sc := .root.Values.global.securityContext -}}
+{{- $sc := .securityContext | default (dict "enabled" false) -}}
 {{- if $sc.enabled }}
 securityContext:
-  {{- if $sc.runAsNonRoot }}
   runAsNonRoot: true
   runAsUser: {{ .uid | int }}
   runAsGroup: {{ .gid | int }}
   fsGroup: {{ .gid | int }}
   fsGroupChangePolicy: OnRootMismatch
-  {{- end }}
   seccompProfile:
     type: RuntimeDefault
 {{- end }}
@@ -114,7 +112,7 @@ Usage (with extra capabilities, e.g., NET_BIND_SERVICE for ports < 1024):
   {{- include "swanlab.containerSecurityContext" (dict "root" . "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
 */}}
 {{- define "swanlab.containerSecurityContext" -}}
-{{- $sc := .root.Values.global.securityContext -}}
+{{- $sc := .securityContext | default (dict "enabled" false) -}}
 {{- if $sc.enabled }}
 securityContext:
   allowPrivilegeEscalation: false

--- a/charts/self-hosted/templates/_helpers.tpl
+++ b/charts/self-hosted/templates/_helpers.tpl
@@ -99,6 +99,15 @@ securityContext:
   fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault
+  {{- /* 容器需监听 <1024 特权端口时（如 traefik/nginx 的 80），降低本 pod 网络命名空间的
+       非特权端口起始值，使非 root 进程可直接绑定。相比 NET_BIND_SERVICE capability
+       更可靠：capability 在 containerd 运行时下经 shell entrypoint exec 后会丢失，
+       而 sysctl 是内核级检查，与运行时无关。要求节点内核 >= 4.11。 */ -}}
+  {{- if .allowPrivilegedPorts }}
+  sysctls:
+    - name: net.ipv4.ip_unprivileged_port_start
+      value: "80"
+  {{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/self-hosted/templates/_helpers.tpl
+++ b/charts/self-hosted/templates/_helpers.tpl
@@ -139,6 +139,47 @@ securityContext:
 
 
 {{/*
+Root initContainer that aligns data-volume ownership with the service user before
+startup. Rendered automatically when the owning service enables securityContext.
+Needed for volumes whose files are owned by root (e.g. data written before
+hardening), or clusters whose CSI fsGroupPolicy makes fsGroup ineffective.
+Incompatible with the restricted PodSecurityStandard (root initContainer).
+
+Usage:
+  {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000 "volumeName" "<volume-name>" "mountPath" "/data") | trim) }}
+  initContainers:
+    {{- . | nindent 8 }}
+  {{- end }}
+*/}}
+{{- define "swanlab.volumePermissionsInit" -}}
+{{- $sc := .sc | default (dict "enabled" false) -}}
+{{- if $sc.enabled -}}
+- name: init-volume-permissions
+  image: {{ include "swanlab.helperImage" .root }}
+  imagePullPolicy: {{ include "swanlab.helperPullPolicy" .root }}
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      find {{ .mountPath }} ! -user {{ .uid }} -exec chown -R {{ .uid }}:{{ .gid }} {} \;
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - CHOWN
+        - DAC_OVERRIDE
+  volumeMounts:
+    - name: {{ .volumeName }}
+      mountPath: {{ .mountPath }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Pod Distribution Constraints Configuration (Based on Topology Spread Constraints)
 
 Usage: `{{ include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.component.selectorLabels" .) }}`

--- a/charts/self-hosted/templates/_helpers.tpl
+++ b/charts/self-hosted/templates/_helpers.tpl
@@ -81,6 +81,55 @@ Helper Image Pull Policy
 {{- $.Values.helper.image.pullPolicy }}
 {{- end }}
 
+{{/*
+Pod-level security context.
+Generates a securityContext block for the pod spec based on global.securityContext settings.
+
+Usage: {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
+The uid and gid are used as runAsUser/runAsGroup/fsGroup when global.securityContext.runAsNonRoot is true.
+*/}}
+{{- define "swanlab.podSecurityContext" -}}
+{{- $sc := .root.Values.global.securityContext -}}
+{{- if $sc.enabled }}
+securityContext:
+  {{- if $sc.runAsNonRoot }}
+  runAsNonRoot: true
+  runAsUser: {{ .uid | int }}
+  runAsGroup: {{ .gid | int }}
+  fsGroup: {{ .gid | int }}
+  fsGroupChangePolicy: OnRootMismatch
+  {{- end }}
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}
+{{- end -}}
+
+{{/*
+Container-level security context.
+Generates a securityContext block for a container spec.
+
+Usage (no extra capabilities):
+  {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+Usage (with extra capabilities, e.g., NET_BIND_SERVICE for ports < 1024):
+  {{- include "swanlab.containerSecurityContext" (dict "root" . "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
+*/}}
+{{- define "swanlab.containerSecurityContext" -}}
+{{- $sc := .root.Values.global.securityContext -}}
+{{- if $sc.enabled }}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    {{- if .addCaps }}
+    add:
+      {{- range .addCaps }}
+      - {{ . }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end -}}
+
 
 {{/*
 Pod Distribution Constraints Configuration (Based on Topology Spread Constraints)

--- a/charts/self-hosted/templates/clickhouse/deployment.yaml
+++ b/charts/self-hosted/templates/clickhouse/deployment.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.clickhouse.securityContext "uid" 101 "gid" 101 "volumeName" (printf "%s-volume" (include "swanlab.clickhouse.fullname" .)) "mountPath" "/var/lib/clickhouse") | trim) }}
+      initContainers:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
       - name: clickhouse
         image: "{{ .Values.dependencies.clickhouse.image.repository }}:{{ .Values.dependencies.clickhouse.image.tag }}"

--- a/charts/self-hosted/templates/clickhouse/deployment.yaml
+++ b/charts/self-hosted/templates/clickhouse/deployment.yaml
@@ -27,7 +27,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.clickhouse.securityContext "uid" 101 "gid" 101) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.clickhouse.securityContext "uid" 101 "gid" 101) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -76,7 +78,9 @@ spec:
             subPath: prometheus.xml
             readOnly: true
           {{- end }}
-        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.clickhouse.securityContext) | nindent 8 }}
+        {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.clickhouse.securityContext) | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- if .Values.dependencies.clickhouse.resources }}
         resources:
         {{- toYaml .Values.dependencies.clickhouse.resources | nindent 12 }}

--- a/charts/self-hosted/templates/clickhouse/deployment.yaml
+++ b/charts/self-hosted/templates/clickhouse/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 101 "gid" 101) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.clickhouse.securityContext "uid" 101 "gid" 101) | nindent 6 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -76,7 +76,7 @@ spec:
             subPath: prometheus.xml
             readOnly: true
           {{- end }}
-        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
+        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.clickhouse.securityContext) | nindent 8 }}
         {{- if .Values.dependencies.clickhouse.resources }}
         resources:
         {{- toYaml .Values.dependencies.clickhouse.resources | nindent 12 }}

--- a/charts/self-hosted/templates/clickhouse/deployment.yaml
+++ b/charts/self-hosted/templates/clickhouse/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 101 "gid" 101) | nindent 6 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -75,6 +76,7 @@ spec:
             subPath: prometheus.xml
             readOnly: true
           {{- end }}
+        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
         {{- if .Values.dependencies.clickhouse.resources }}
         resources:
         {{- toYaml .Values.dependencies.clickhouse.resources | nindent 12 }}

--- a/charts/self-hosted/templates/clickhouse/deployment.yaml
+++ b/charts/self-hosted/templates/clickhouse/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.clickhouse.securityContext "uid" 101 "gid" 101 "volumeName" (printf "%s-volume" (include "swanlab.clickhouse.fullname" .)) "mountPath" "/var/lib/clickhouse") | trim) }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "securityContext" .Values.dependencies.clickhouse.securityContext "uid" 101 "gid" 101 "volumeName" (printf "%s-volume" (include "swanlab.clickhouse.fullname" .)) "mountPath" "/var/lib/clickhouse") | trim) }}
       initContainers:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/self-hosted/templates/gateway/deployment.yaml
+++ b/charts/self-hosted/templates/gateway/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "uid" 65532 "gid" 65532) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "uid" 65532 "gid" 65532 "allowPrivilegedPorts" true) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.gateway.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.gateway.nodeSelector" . | trim) }}
       nodeSelector:
@@ -75,7 +75,7 @@ spec:
               subPath: "dynamic.yaml"
             - name: identify-plugin
               mountPath: /plugins-local/src/github.com/swanhubx/swanlab-helper
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext) | nindent 10 }}
         {{- if .Values.gateway.resources }}
           resources:
         {{- toYaml .Values.gateway.resources | nindent 12 }}

--- a/charts/self-hosted/templates/gateway/deployment.yaml
+++ b/charts/self-hosted/templates/gateway/deployment.yaml
@@ -27,7 +27,9 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "uid" 65532 "gid" 65532 "allowPrivilegedPorts" true) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "uid" 65532 "gid" 65532 "allowPrivilegedPorts" true) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.gateway.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.gateway.nodeSelector" . | trim) }}
       nodeSelector:
@@ -48,7 +50,9 @@ spec:
             - name: identify-plugin
               # Mount path for the shared volume
               mountPath: /plugins-tmp
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -75,7 +79,9 @@ spec:
               subPath: "dynamic.yaml"
             - name: identify-plugin
               mountPath: /plugins-local/src/github.com/swanhubx/swanlab-helper
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
         {{- if .Values.gateway.resources }}
           resources:
         {{- toYaml .Values.gateway.resources | nindent 12 }}

--- a/charts/self-hosted/templates/gateway/deployment.yaml
+++ b/charts/self-hosted/templates/gateway/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 65532 "gid" 65532) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.gateway.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.gateway.nodeSelector" . | trim) }}
       nodeSelector:
@@ -47,6 +48,7 @@ spec:
             - name: identify-plugin
               # Mount path for the shared volume
               mountPath: /plugins-tmp
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -73,6 +75,7 @@ spec:
               subPath: "dynamic.yaml"
             - name: identify-plugin
               mountPath: /plugins-local/src/github.com/swanhubx/swanlab-helper
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
         {{- if .Values.gateway.resources }}
           resources:
         {{- toYaml .Values.gateway.resources | nindent 12 }}

--- a/charts/self-hosted/templates/gateway/deployment.yaml
+++ b/charts/self-hosted/templates/gateway/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 65532 "gid" 65532) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "uid" 65532 "gid" 65532) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.gateway.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.gateway.nodeSelector" . | trim) }}
       nodeSelector:
@@ -48,7 +48,7 @@ spec:
             - name: identify-plugin
               # Mount path for the shared volume
               mountPath: /plugins-tmp
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext) | nindent 10 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -75,7 +75,7 @@ spec:
               subPath: "dynamic.yaml"
             - name: identify-plugin
               mountPath: /plugins-local/src/github.com/swanhubx/swanlab-helper
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.gateway.securityContext "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
         {{- if .Values.gateway.resources }}
           resources:
         {{- toYaml .Values.gateway.resources | nindent 12 }}

--- a/charts/self-hosted/templates/postgres/deployment.yaml
+++ b/charts/self-hosted/templates/postgres/deployment.yaml
@@ -38,10 +38,8 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      # 部分存储类创建的卷权限不是 postgres 用户可写，使用 initContainer 修正权限
-      # 实测部分存储、k8s版本下单纯设置 fsGroup 无效，需要用 initContainer 修改目录属主
-      securityContext:
-        fsGroup: 999
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 999 "gid" 999) | nindent 6 }}
+      # 预创建 subPath；卷的组权限由 fsGroup 处理，不再使用 root chown。
       initContainers:
         - name: init-postgres-fs
           image: {{ include "swanlab.helperImage" . }}
@@ -49,9 +47,8 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "mkdir -p /var/lib/postgresql/data && chmod 700 /var/lib/postgresql/data && chown -R 999:999 /var/lib/postgresql/data"
-          securityContext:
-            runAsUser: 0
+            - "mkdir -p /var/lib/postgresql/data"
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
           volumeMounts:
             - name: {{ include "swanlab.postgres.fullname" . }}-volume
               mountPath: /var/lib/postgresql
@@ -84,6 +81,7 @@ spec:
           - mountPath: /var/lib/postgresql/data
             subPath: data
             name: {{ include "swanlab.postgres.fullname" . }}-volume
+        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
         {{- if .Values.dependencies.postgres.resources }}
         resources:
         {{- toYaml .Values.dependencies.postgres.resources | nindent 12 }}

--- a/charts/self-hosted/templates/postgres/deployment.yaml
+++ b/charts/self-hosted/templates/postgres/deployment.yaml
@@ -38,8 +38,9 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 999 "gid" 999) | nindent 6 }}
-      # 预创建 subPath；卷的组权限由 fsGroup 处理，不再使用 root chown。
+      {{- if .Values.dependencies.postgres.securityContext.enabled }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext "uid" 999 "gid" 999) | nindent 6 }}
+      {{- end }}
       initContainers:
         - name: init-postgres-fs
           image: {{ include "swanlab.helperImage" . }}
@@ -47,8 +48,16 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "mkdir -p /var/lib/postgresql/data"
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+            - >-
+              mkdir -p /var/lib/postgresql/data &&
+              {{- if .Values.dependencies.postgres.securityContext.enabled }}
+              true
+              {{- else }}
+              chmod 700 /var/lib/postgresql/data && chown -R 999:999 /var/lib/postgresql/data
+              {{- end }}
+          {{- if .Values.dependencies.postgres.securityContext.enabled }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext) | nindent 10 }}
+          {{- end }}
           volumeMounts:
             - name: {{ include "swanlab.postgres.fullname" . }}-volume
               mountPath: /var/lib/postgresql
@@ -81,7 +90,9 @@ spec:
           - mountPath: /var/lib/postgresql/data
             subPath: data
             name: {{ include "swanlab.postgres.fullname" . }}-volume
-        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
+        {{- if .Values.dependencies.postgres.securityContext.enabled }}
+        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext) | nindent 8 }}
+        {{- end }}
         {{- if .Values.dependencies.postgres.resources }}
         resources:
         {{- toYaml .Values.dependencies.postgres.resources | nindent 12 }}

--- a/charts/self-hosted/templates/postgres/deployment.yaml
+++ b/charts/self-hosted/templates/postgres/deployment.yaml
@@ -51,6 +51,9 @@ spec:
         fsGroup: 999
       {{- end }}
       initContainers:
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.postgres.securityContext "uid" 999 "gid" 999 "volumeName" (printf "%s-volume" (include "swanlab.postgres.fullname" .)) "mountPath" "/var/lib/postgresql") | trim) }}
+      {{- . | nindent 8 }}
+      {{- end }}
         - name: init-postgres-fs
           image: {{ include "swanlab.helperImage" . }}
           imagePullPolicy: {{ include "swanlab.helperPullPolicy" . }}

--- a/charts/self-hosted/templates/postgres/deployment.yaml
+++ b/charts/self-hosted/templates/postgres/deployment.yaml
@@ -39,7 +39,16 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
       {{- if .Values.dependencies.postgres.securityContext.enabled }}
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext "uid" 999 "gid" 999) | nindent 6 }}
+      # 注意：开启加固后卷权限完全依赖 fsGroup + OnRootMismatch（subPath 内已存在的目录不受递归修正），
+      # 实测部分存储类/CSI 下 fsGroup 不可靠，此类环境请保持 securityContext.enabled=false
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext "uid" 999 "gid" 999) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
+      {{- else }}
+      # 部分存储类创建的卷权限不是 postgres 用户可写，使用 initContainer 修正权限
+      # 实测部分存储、k8s版本下单纯设置 fsGroup 无效，需要用 initContainer 修改目录属主
+      securityContext:
+        fsGroup: 999
       {{- end }}
       initContainers:
         - name: init-postgres-fs
@@ -48,15 +57,20 @@ spec:
           command:
             - "sh"
             - "-c"
+            {{- if .Values.dependencies.postgres.securityContext.enabled }}
             - >-
               mkdir -p /var/lib/postgresql/data &&
-              {{- if .Values.dependencies.postgres.securityContext.enabled }}
               true
-              {{- else }}
-              chmod 700 /var/lib/postgresql/data && chown -R 999:999 /var/lib/postgresql/data
-              {{- end }}
+            {{- else }}
+            - "mkdir -p /var/lib/postgresql/data && chmod 700 /var/lib/postgresql/data && chown -R 999:999 /var/lib/postgresql/data"
+            {{- end }}
           {{- if .Values.dependencies.postgres.securityContext.enabled }}
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
+          {{- else }}
+          securityContext:
+            runAsUser: 0
           {{- end }}
           volumeMounts:
             - name: {{ include "swanlab.postgres.fullname" . }}-volume
@@ -91,7 +105,9 @@ spec:
             subPath: data
             name: {{ include "swanlab.postgres.fullname" . }}-volume
         {{- if .Values.dependencies.postgres.securityContext.enabled }}
-        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext) | nindent 8 }}
+        {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext) | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- end }}
         {{- if .Values.dependencies.postgres.resources }}
         resources:

--- a/charts/self-hosted/templates/postgres/deployment.yaml
+++ b/charts/self-hosted/templates/postgres/deployment.yaml
@@ -39,8 +39,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
       {{- if .Values.dependencies.postgres.securityContext.enabled }}
-      # 注意：开启加固后卷权限完全依赖 fsGroup + OnRootMismatch（subPath 内已存在的目录不受递归修正），
-      # 实测部分存储类/CSI 下 fsGroup 不可靠，此类环境请保持 securityContext.enabled=false
+      # 卷属主由下方 init-volume-permissions 修正：fsGroup 在部分 CSI 驱动上不可靠，
+      # 且 kubelet 不会递归修正 subPath 内部。该 initContainer 以 root 运行，
+      # 集群强制 restricted PSS 时请保持 securityContext.enabled=false。
       {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext "uid" 999 "gid" 999) | trim) }}
       {{- . | nindent 6 }}
       {{- end }}
@@ -51,7 +52,7 @@ spec:
         fsGroup: 999
       {{- end }}
       initContainers:
-      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.postgres.securityContext "uid" 999 "gid" 999 "volumeName" (printf "%s-volume" (include "swanlab.postgres.fullname" .)) "mountPath" "/var/lib/postgresql") | trim) }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "securityContext" .Values.dependencies.postgres.securityContext "uid" 999 "gid" 999 "volumeName" (printf "%s-volume" (include "swanlab.postgres.fullname" .)) "mountPath" "/var/lib/postgresql") | trim) }}
       {{- . | nindent 8 }}
       {{- end }}
         - name: init-postgres-fs
@@ -61,9 +62,11 @@ spec:
             - "sh"
             - "-c"
             {{- if .Values.dependencies.postgres.securityContext.enabled }}
+            # PG >= 15 要求数据目录权限为 0700/0750，否则拒绝启动；
+            # 属主已由 init-volume-permissions 修正为 999，此容器以 999 运行，有权 chmod 自有目录
             - >-
               mkdir -p /var/lib/postgresql/data &&
-              true
+              chmod 700 /var/lib/postgresql/data
             {{- else }}
             - "mkdir -p /var/lib/postgresql/data && chmod 700 /var/lib/postgresql/data && chown -R 999:999 /var/lib/postgresql/data"
             {{- end }}

--- a/charts/self-hosted/templates/redis/deployment.yaml
+++ b/charts/self-hosted/templates/redis/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000 "volumeName" (printf "%s-volume" (include "swanlab.redis.fullname" .)) "mountPath" "/data") | trim) }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000 "volumeName" (printf "%s-volume" (include "swanlab.redis.fullname" .)) "mountPath" "/data") | trim) }}
       initContainers:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/self-hosted/templates/redis/deployment.yaml
+++ b/charts/self-hosted/templates/redis/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -43,13 +43,18 @@ spec:
       - name: redis
         image: "{{ .Values.dependencies.redis.image.repository }}:{{ .Values.dependencies.redis.image.tag }}"
         imagePullPolicy: {{ .Values.dependencies.redis.image.pullPolicy }}
+        {{- if .Values.dependencies.redis.persistence.aof.enabled }}
+        env:
+          - name: REDIS_ARGS
+            value: "--appendonly yes --appendfsync {{ .Values.dependencies.redis.persistence.aof.appendFsync }}"
+        {{- end }}
         ports:
           - containerPort: {{ include "swanlab.redis.port" . }}
             name: redis
         volumeMounts:
           - mountPath: /data
             name: {{ include "swanlab.redis.fullname" . }}-volume
-        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
+        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext) | nindent 8 }}
         {{- if .Values.dependencies.redis.resources }}
         resources:
         {{- toYaml .Values.dependencies.redis.resources | nindent 12 }}

--- a/charts/self-hosted/templates/redis/deployment.yaml
+++ b/charts/self-hosted/templates/redis/deployment.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000 "volumeName" (printf "%s-volume" (include "swanlab.redis.fullname" .)) "mountPath" "/data") | trim) }}
+      initContainers:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
       - name: redis
         image: "{{ .Values.dependencies.redis.image.repository }}:{{ .Values.dependencies.redis.image.tag }}"

--- a/charts/self-hosted/templates/redis/deployment.yaml
+++ b/charts/self-hosted/templates/redis/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -48,6 +49,7 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: {{ include "swanlab.redis.fullname" . }}-volume
+        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
         {{- if .Values.dependencies.redis.resources }}
         resources:
         {{- toYaml .Values.dependencies.redis.resources | nindent 12 }}

--- a/charts/self-hosted/templates/redis/deployment.yaml
+++ b/charts/self-hosted/templates/redis/deployment.yaml
@@ -27,7 +27,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext "uid" 1000 "gid" 1000) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -54,7 +56,9 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: {{ include "swanlab.redis.fullname" . }}-volume
-        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext) | nindent 8 }}
+        {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.redis.securityContext) | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- if .Values.dependencies.redis.resources }}
         resources:
         {{- toYaml .Values.dependencies.redis.resources | nindent 12 }}

--- a/charts/self-hosted/templates/s3/deployment.yaml
+++ b/charts/self-hosted/templates/s3/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000 "volumeName" (printf "%s-volume" (include "swanlab.s3.fullname" .)) "mountPath" "/data") | trim) }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000 "volumeName" (printf "%s-volume" (include "swanlab.s3.fullname" .)) "mountPath" "/data") | trim) }}
       initContainers:
         {{- . | nindent 8 }}
       {{- end }}
@@ -159,7 +159,7 @@ spec:
             - name: MINIO_PUBLIC_BUCKET
               value: "{{ include "swanlab.s3.public.bucket" . }}"
             {{- if .Values.dependencies.s3.securityContext.enabled }}
-            # 非 root 运行时 mc 无法写默认 HOME（/root），重定向到 /tmp，否则 mc alias set 失败
+            # mc 配置写在 HOME 下；非 root 运行时 /root 不可写，重定向到 /tmp
             - name: HOME
               value: /tmp
             {{- end }}

--- a/charts/self-hosted/templates/s3/deployment.yaml
+++ b/charts/self-hosted/templates/s3/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -69,7 +69,7 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: {{ include "swanlab.s3.fullname" . }}-volume
-        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
+        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | nindent 8 }}
         {{- if .Values.dependencies.s3.resources }}
         resources:
         {{- toYaml .Values.dependencies.s3.resources | nindent 12 }}
@@ -104,7 +104,7 @@ spec:
   completions: 1
   template:
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-minio
@@ -124,7 +124,7 @@ spec:
           env:
             - name: MINIO_ENDPOINT
               value: "http://{{ include "swanlab.s3.fullname" . }}:{{ include "swanlab.s3.minio.port" . }}"
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | nindent 10 }}
       containers:
         - name: minio-mc-job
           image: "{{ .Values.dependencies.s3.mcImage.repository }}:{{ .Values.dependencies.s3.mcImage.tag }}"
@@ -159,5 +159,5 @@ spec:
               # 3. public bucket
               mc mb --ignore-existing swanlab-minio/$MINIO_PUBLIC_BUCKET
               mc anonymous set public swanlab-minio/$MINIO_PUBLIC_BUCKET
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | nindent 10 }}
 {{- end }}

--- a/charts/self-hosted/templates/s3/deployment.yaml
+++ b/charts/self-hosted/templates/s3/deployment.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000 "volumeName" (printf "%s-volume" (include "swanlab.s3.fullname" .)) "mountPath" "/data") | trim) }}
+      initContainers:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
       - name: s3
         image: "{{ .Values.dependencies.s3.image.repository }}:{{ .Values.dependencies.s3.image.tag }}"

--- a/charts/self-hosted/templates/s3/deployment.yaml
+++ b/charts/self-hosted/templates/s3/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -68,6 +69,7 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: {{ include "swanlab.s3.fullname" . }}-volume
+        {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 8 }}
         {{- if .Values.dependencies.s3.resources }}
         resources:
         {{- toYaml .Values.dependencies.s3.resources | nindent 12 }}
@@ -102,6 +104,7 @@ spec:
   completions: 1
   template:
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-minio
@@ -121,6 +124,7 @@ spec:
           env:
             - name: MINIO_ENDPOINT
               value: "http://{{ include "swanlab.s3.fullname" . }}:{{ include "swanlab.s3.minio.port" . }}"
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
       containers:
         - name: minio-mc-job
           image: "{{ .Values.dependencies.s3.mcImage.repository }}:{{ .Values.dependencies.s3.mcImage.tag }}"
@@ -155,4 +159,5 @@ spec:
               # 3. public bucket
               mc mb --ignore-existing swanlab-minio/$MINIO_PUBLIC_BUCKET
               mc anonymous set public swanlab-minio/$MINIO_PUBLIC_BUCKET
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
 {{- end }}

--- a/charts/self-hosted/templates/s3/deployment.yaml
+++ b/charts/self-hosted/templates/s3/deployment.yaml
@@ -27,7 +27,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
@@ -69,7 +71,9 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: {{ include "swanlab.s3.fullname" . }}-volume
-        {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | nindent 8 }}
+        {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- if .Values.dependencies.s3.resources }}
         resources:
         {{- toYaml .Values.dependencies.s3.resources | nindent 12 }}
@@ -104,7 +108,9 @@ spec:
   completions: 1
   template:
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext "uid" 1000 "gid" 1000) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-minio
@@ -124,7 +130,9 @@ spec:
           env:
             - name: MINIO_ENDPOINT
               value: "http://{{ include "swanlab.s3.fullname" . }}:{{ include "swanlab.s3.minio.port" . }}"
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
       containers:
         - name: minio-mc-job
           image: "{{ .Values.dependencies.s3.mcImage.repository }}:{{ .Values.dependencies.s3.mcImage.tag }}"
@@ -146,6 +154,11 @@ spec:
               value: "{{ include "swanlab.s3.private.bucket" . }}"
             - name: MINIO_PUBLIC_BUCKET
               value: "{{ include "swanlab.s3.public.bucket" . }}"
+            {{- if .Values.dependencies.s3.securityContext.enabled }}
+            # 非 root 运行时 mc 无法写默认 HOME（/root），重定向到 /tmp，否则 mc alias set 失败
+            - name: HOME
+              value: /tmp
+            {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -159,5 +172,7 @@ spec:
               # 3. public bucket
               mc mb --ignore-existing swanlab-minio/$MINIO_PUBLIC_BUCKET
               mc anonymous set public swanlab-minio/$MINIO_PUBLIC_BUCKET
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.dependencies.s3.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
 {{- end }}

--- a/charts/self-hosted/templates/swanlab-auth/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-auth/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 65532 "gid" 65532) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext "uid" 65532 "gid" 65532) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.auth.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.auth.nodeSelector" . | trim) }}
       nodeSelector:
@@ -96,7 +96,7 @@ spec:
               check_service "Redis" "$REDIS_URL" "6379"
 
               echo "🎉 All dependencies are reachable!"
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext) | nindent 10 }}
       containers:
         - name: auth
           image: {{ include "swanlab.auth.image" . | quote }}
@@ -118,7 +118,7 @@ spec:
             - name: SA_SSO_PUBLIC_URL
               value: {{ . | quote }}
             {{- end }}
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext) | nindent 10 }}
         {{- if .Values.service.auth.resources }}
           resources:
         {{- toYaml .Values.service.auth.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-auth/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-auth/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 65532 "gid" 65532) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.auth.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.auth.nodeSelector" . | trim) }}
       nodeSelector:
@@ -95,6 +96,7 @@ spec:
               check_service "Redis" "$REDIS_URL" "6379"
 
               echo "🎉 All dependencies are reachable!"
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
       containers:
         - name: auth
           image: {{ include "swanlab.auth.image" . | quote }}
@@ -116,6 +118,7 @@ spec:
             - name: SA_SSO_PUBLIC_URL
               value: {{ . | quote }}
             {{- end }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
         {{- if .Values.service.auth.resources }}
           resources:
         {{- toYaml .Values.service.auth.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-auth/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-auth/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext "uid" 65532 "gid" 65532) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext "uid" 65532 "gid" 65532) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.auth.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.auth.nodeSelector" . | trim) }}
       nodeSelector:
@@ -96,7 +98,9 @@ spec:
               check_service "Redis" "$REDIS_URL" "6379"
 
               echo "🎉 All dependencies are reachable!"
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
       containers:
         - name: auth
           image: {{ include "swanlab.auth.image" . | quote }}
@@ -118,7 +122,9 @@ spec:
             - name: SA_SSO_PUBLIC_URL
               value: {{ . | quote }}
             {{- end }}
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.auth.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
         {{- if .Values.service.auth.resources }}
           resources:
         {{- toYaml .Values.service.auth.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext "uid" 101 "gid" 101 "allowPrivilegedPorts" true) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext "uid" 101 "gid" 101 "allowPrivilegedPorts" true) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.cloud.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.cloud.nodeSelector" . | trim) }}
       nodeSelector:
@@ -45,21 +47,28 @@ spec:
           ports:
             - containerPort: 80
               name: web
+          {{- if .Values.service.cloud.securityContext.enabled }}
+          # 非 root 运行时 nginx 需要可写的缓存与 pid 目录
           volumeMounts:
             - name: nginx-cache
               mountPath: /var/cache/nginx
             - name: nginx-run
               mountPath: /var/run
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext) | nindent 10 }}
+          {{- end }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
         {{- if .Values.service.cloud.resources }}
           resources:
         {{- toYaml .Values.service.cloud.resources | nindent 12 }}
         {{- end }}
+      {{- if .Values.service.cloud.securityContext.enabled }}
       volumes:
         - name: nginx-cache
           emptyDir: {}
         - name: nginx-run
           emptyDir: {}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext "uid" 101 "gid" 101) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext "uid" 101 "gid" 101 "allowPrivilegedPorts" true) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.cloud.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.cloud.nodeSelector" . | trim) }}
       nodeSelector:
@@ -50,7 +50,7 @@ spec:
               mountPath: /var/cache/nginx
             - name: nginx-run
               mountPath: /var/run
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext) | nindent 10 }}
         {{- if .Values.service.cloud.resources }}
           resources:
         {{- toYaml .Values.service.cloud.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 101 "gid" 101) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.cloud.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.cloud.nodeSelector" . | trim) }}
       nodeSelector:
@@ -44,10 +45,21 @@ spec:
           ports:
             - containerPort: 80
               name: web
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
         {{- if .Values.service.cloud.resources }}
           resources:
         {{- toYaml .Values.service.cloud.resources | nindent 12 }}
         {{- end }}
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-cloud/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 101 "gid" 101) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext "uid" 101 "gid" 101) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.cloud.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.cloud.nodeSelector" . | trim) }}
       nodeSelector:
@@ -50,7 +50,7 @@ spec:
               mountPath: /var/cache/nginx
             - name: nginx-run
               mountPath: /var/run
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.cloud.securityContext "addCaps" (list "NET_BIND_SERVICE")) | nindent 10 }}
         {{- if .Values.service.cloud.resources }}
           resources:
         {{- toYaml .Values.service.cloud.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-house/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-house/deployment.yaml
@@ -26,7 +26,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext "uid" 65532 "gid" 65532) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext "uid" 65532 "gid" 65532) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.house.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.house.nodeSelector" . | trim) }}
       nodeSelector:
@@ -103,7 +105,26 @@ spec:
               echo "✅ Vector is ready!"
 
               echo "🎉 All dependencies are ready. Proceeding to main container..."
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
+        {{- if .Values.service.house.securityContext.enabled }}
+        # 非 root 运行时 /app/playground 不可写，挂 emptyDir 提供可写目录；
+        # 镜像内置的 playground 配置（如更新用 yaml 依赖）会在每次 pod 启动时由本 initContainer
+        # 从镜像层回填到 emptyDir，避免被遮蔽丢失，也保证镜像升级后配置始终以镜像内容为准
+        - name: init-config
+          image: {{ include "swanlab.house.image" . | quote }}
+          imagePullPolicy: {{ .Values.service.house.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - '[ -d /app/playground ] && cp -r /app/playground/. /playground-workdir/ || true'
+          volumeMounts:
+            - name: house-workdir
+              mountPath: /playground-workdir
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
+        {{- end }}
       containers:
         - name: house
           image: {{ include "swanlab.house.image" . | quote }}
@@ -173,17 +194,23 @@ spec:
                 secretKeyRef:
                   name: {{ include "swanlab.s3.secretName" .}}
                   key: secretKey
+          {{- if .Values.service.house.securityContext.enabled }}
           volumeMounts:
             - name: house-workdir
               mountPath: /app/playground
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext) | nindent 10 }}
+          {{- end }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
         {{- if .Values.service.house.resources }}
           resources:
         {{- toYaml .Values.service.house.resources | nindent 12 }}
         {{- end }}
+      {{- if .Values.service.house.securityContext.enabled }}
       volumes:
         - name: house-workdir
           emptyDir: {}
+      {{- end }}
 
 ---
 

--- a/charts/self-hosted/templates/swanlab-house/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-house/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 65532 "gid" 65532) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.house.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.house.nodeSelector" . | trim) }}
       nodeSelector:
@@ -102,6 +103,7 @@ spec:
               echo "✅ Vector is ready!"
 
               echo "🎉 All dependencies are ready. Proceeding to main container..."
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
       containers:
         - name: house
           image: {{ include "swanlab.house.image" . | quote }}
@@ -171,10 +173,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "swanlab.s3.secretName" .}}
                   key: secretKey
+          volumeMounts:
+            - name: house-workdir
+              mountPath: /app/playground
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
         {{- if .Values.service.house.resources }}
           resources:
         {{- toYaml .Values.service.house.resources | nindent 12 }}
         {{- end }}
+      volumes:
+        - name: house-workdir
+          emptyDir: {}
 
 ---
 

--- a/charts/self-hosted/templates/swanlab-house/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-house/deployment.yaml
@@ -109,9 +109,8 @@ spec:
           {{- . | nindent 10 }}
           {{- end }}
         {{- if .Values.service.house.securityContext.enabled }}
-        # 非 root 运行时 /app/playground 不可写，挂 emptyDir 提供可写目录；
-        # 镜像内置的 playground 配置（如更新用 yaml 依赖）会在每次 pod 启动时由本 initContainer
-        # 从镜像层回填到 emptyDir，避免被遮蔽丢失，也保证镜像升级后配置始终以镜像内容为准
+        # 非 root 运行时镜像内 /app/playground 不可写；每次启动将其内容拷入可写
+        # emptyDir，保证镜像升级后配置始终以镜像内容为准
         - name: init-config
           image: {{ include "swanlab.house.image" . | quote }}
           imagePullPolicy: {{ .Values.service.house.image.pullPolicy }}

--- a/charts/self-hosted/templates/swanlab-house/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-house/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 65532 "gid" 65532) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext "uid" 65532 "gid" 65532) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.house.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.house.nodeSelector" . | trim) }}
       nodeSelector:
@@ -103,7 +103,7 @@ spec:
               echo "✅ Vector is ready!"
 
               echo "🎉 All dependencies are ready. Proceeding to main container..."
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext) | nindent 10 }}
       containers:
         - name: house
           image: {{ include "swanlab.house.image" . | quote }}
@@ -176,7 +176,7 @@ spec:
           volumeMounts:
             - name: house-workdir
               mountPath: /app/playground
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.house.securityContext) | nindent 10 }}
         {{- if .Values.service.house.resources }}
           resources:
         {{- toYaml .Values.service.house.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-next/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-next/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1001 "gid" 1001) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext "uid" 1001 "gid" 1001) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.next.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.next.nodeSelector" . | trim) }}
       nodeSelector:
@@ -101,7 +101,7 @@ spec:
               check_url "SwanLab House" "$SWANLAB_HOUSE_URL"
 
               echo "🎉 All services are reachable!"
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext) | nindent 10 }}
       containers:
         - name: server
           image: {{ include "swanlab.next.image" . | quote }}
@@ -122,7 +122,7 @@ spec:
             - name: API_DISPLAY_HOST
               value: {{ . | quote }}
             {{- end }}
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext) | nindent 10 }}
         {{- if .Values.service.next.resources }}
           resources:
         {{- toYaml .Values.service.next.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-next/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-next/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1001 "gid" 1001) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.next.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.next.nodeSelector" . | trim) }}
       nodeSelector:
@@ -100,6 +101,7 @@ spec:
               check_url "SwanLab House" "$SWANLAB_HOUSE_URL"
 
               echo "🎉 All services are reachable!"
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
       containers:
         - name: server
           image: {{ include "swanlab.next.image" . | quote }}
@@ -120,6 +122,7 @@ spec:
             - name: API_DISPLAY_HOST
               value: {{ . | quote }}
             {{- end }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
         {{- if .Values.service.next.resources }}
           resources:
         {{- toYaml .Values.service.next.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-next/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-next/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext "uid" 1001 "gid" 1001) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext "uid" 1001 "gid" 1001) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.next.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.next.nodeSelector" . | trim) }}
       nodeSelector:
@@ -101,7 +103,9 @@ spec:
               check_url "SwanLab House" "$SWANLAB_HOUSE_URL"
 
               echo "🎉 All services are reachable!"
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
       containers:
         - name: server
           image: {{ include "swanlab.next.image" . | quote }}
@@ -122,7 +126,9 @@ spec:
             - name: API_DISPLAY_HOST
               value: {{ . | quote }}
             {{- end }}
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.next.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
         {{- if .Values.service.next.resources }}
           resources:
         {{- toYaml .Values.service.next.resources | nindent 12 }}

--- a/charts/self-hosted/templates/swanlab-server/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-server/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.server.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.server.nodeSelector" . | trim) }}
       nodeSelector:
@@ -111,6 +112,7 @@ spec:
               check_service "Postgres Replica" "$POSTGRES_REPLICA_URL" "5432"
 
               echo "🎉 All dependencies are ready!"
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
       containers:
         - name: server
           image: {{ include "swanlab.server.image" . | quote }}
@@ -123,6 +125,10 @@ spec:
             - -c
             - npx prisma migrate deploy && node migrate.js && pm2-runtime app.js
           env:
+            - name: HOME
+              value: /tmp
+            - name: PM2_HOME
+              value: /tmp/.pm2
             # K8s downward API：kubelet 注入 pod 名，不调 API server
             # 应用读取 POD_NAME 暴露 swanlab_pod_info{pod=...}=1，供 Grafana join 显示 pod 名
             - name: POD_NAME
@@ -197,10 +203,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "swanlab.s3.secretName" . }}
                   key: secretKey
+          volumeMounts:
+            - name: server-tmp
+              mountPath: /tmp
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
         {{- if .Values.service.server.resources }}
           resources:
         {{- toYaml .Values.service.server.resources | nindent 12 }}
         {{- end }}
+      volumes:
+        - name: server-tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-hosted/templates/swanlab-server/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-server/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext "uid" 1000 "gid" 1000) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.server.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.server.nodeSelector" . | trim) }}
       nodeSelector:
@@ -112,7 +114,9 @@ spec:
               check_service "Postgres Replica" "$POSTGRES_REPLICA_URL" "5432"
 
               echo "🎉 All dependencies are ready!"
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
       containers:
         - name: server
           image: {{ include "swanlab.server.image" . | quote }}
@@ -125,10 +129,13 @@ spec:
             - -c
             - npx prisma migrate deploy && node migrate.js && pm2-runtime app.js
           env:
+            {{- if .Values.service.server.securityContext.enabled }}
+            # 非 root 运行时无法写默认 HOME，重定向到可写的 /tmp（emptyDir）
             - name: HOME
               value: /tmp
             - name: PM2_HOME
               value: /tmp/.pm2
+            {{- end }}
             # K8s downward API：kubelet 注入 pod 名，不调 API server
             # 应用读取 POD_NAME 暴露 swanlab_pod_info{pod=...}=1，供 Grafana join 显示 pod 名
             - name: POD_NAME
@@ -203,17 +210,23 @@ spec:
                 secretKeyRef:
                   name: {{ include "swanlab.s3.secretName" . }}
                   key: secretKey
+          {{- if .Values.service.server.securityContext.enabled }}
           volumeMounts:
             - name: server-tmp
               mountPath: /tmp
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext) | nindent 10 }}
+          {{- end }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
         {{- if .Values.service.server.resources }}
           resources:
         {{- toYaml .Values.service.server.resources | nindent 12 }}
         {{- end }}
+      {{- if .Values.service.server.securityContext.enabled }}
       volumes:
         - name: server-tmp
           emptyDir: {}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/self-hosted/templates/swanlab-server/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-server/deployment.yaml
@@ -130,7 +130,7 @@ spec:
             - npx prisma migrate deploy && node migrate.js && pm2-runtime app.js
           env:
             {{- if .Values.service.server.securityContext.enabled }}
-            # 非 root 运行时无法写默认 HOME，重定向到可写的 /tmp（emptyDir）
+            # 非 root 运行时 HOME 不可写，重定向到 /tmp（含 pm2）
             - name: HOME
               value: /tmp
             - name: PM2_HOME

--- a/charts/self-hosted/templates/swanlab-server/deployment.yaml
+++ b/charts/self-hosted/templates/swanlab-server/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.server.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.server.nodeSelector" . | trim) }}
       nodeSelector:
@@ -112,7 +112,7 @@ spec:
               check_service "Postgres Replica" "$POSTGRES_REPLICA_URL" "5432"
 
               echo "🎉 All dependencies are ready!"
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext) | nindent 10 }}
       containers:
         - name: server
           image: {{ include "swanlab.server.image" . | quote }}
@@ -206,7 +206,7 @@ spec:
           volumeMounts:
             - name: server-tmp
               mountPath: /tmp
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.service.server.securityContext) | nindent 10 }}
         {{- if .Values.service.server.resources }}
           resources:
         {{- toYaml .Values.service.server.resources | nindent 12 }}

--- a/charts/self-hosted/templates/vector/statefulset.yaml
+++ b/charts/self-hosted/templates/vector/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
-      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.vector.securityContext "uid" 1000 "gid" 1000 "volumeName" "data" "mountPath" "/var/lib/vector") | trim) }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "securityContext" .Values.vector.securityContext "uid" 1000 "gid" 1000 "volumeName" "data" "mountPath" "/var/lib/vector") | trim) }}
       initContainers:
         {{- . | nindent 8 }}
       {{- end }}

--- a/charts/self-hosted/templates/vector/statefulset.yaml
+++ b/charts/self-hosted/templates/vector/statefulset.yaml
@@ -41,6 +41,10 @@ spec:
       restartPolicy: Always
       imagePullSecrets:
       {{- include "swanlab.imagePullSecrets" . | nindent 8 }}
+      {{- with (include "swanlab.volumePermissionsInit" (dict "root" . "sc" .Values.vector.securityContext "uid" 1000 "gid" 1000 "volumeName" "data" "mountPath" "/var/lib/vector") | trim) }}
+      initContainers:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
         - name: vector
           image: "{{ .Values.vector.image.repository }}:{{ .Values.vector.image.tag }}"

--- a/charts/self-hosted/templates/vector/statefulset.yaml
+++ b/charts/self-hosted/templates/vector/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.vector.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.vector.nodeSelector" . | trim) }}
       nodeSelector:
@@ -90,6 +91,7 @@ spec:
               readOnly: true
             - name: data
               mountPath: /var/lib/vector
+          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
           {{- if .Values.vector.resources }}
           resources:
           {{- toYaml .Values.vector.resources | nindent 12 }}

--- a/charts/self-hosted/templates/vector/statefulset.yaml
+++ b/charts/self-hosted/templates/vector/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.vector.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.vector.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.vector.nodeSelector" . | trim) }}
       nodeSelector:
@@ -91,7 +91,7 @@ spec:
               readOnly: true
             - name: data
               mountPath: /var/lib/vector
-          {{- include "swanlab.containerSecurityContext" (dict "root" .) | nindent 10 }}
+          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.vector.securityContext) | nindent 10 }}
           {{- if .Values.vector.resources }}
           resources:
           {{- toYaml .Values.vector.resources | nindent 12 }}

--- a/charts/self-hosted/templates/vector/statefulset.yaml
+++ b/charts/self-hosted/templates/vector/statefulset.yaml
@@ -26,7 +26,9 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.vector.securityContext "uid" 1000 "gid" 1000) | nindent 6 }}
+      {{- with (include "swanlab.podSecurityContext" (dict "root" . "securityContext" .Values.vector.securityContext "uid" 1000 "gid" 1000) | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- include "swanlab.podAntiAffinity" (list .Values.global.podAntiAffinityPreset "swanlab.vector.selectorLabels" . ) | nindent 6 }}
       {{- with (include "swanlab.vector.nodeSelector" . | trim) }}
       nodeSelector:
@@ -91,7 +93,9 @@ spec:
               readOnly: true
             - name: data
               mountPath: /var/lib/vector
-          {{- include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.vector.securityContext) | nindent 10 }}
+          {{- with (include "swanlab.containerSecurityContext" (dict "root" . "securityContext" .Values.vector.securityContext) | trim) }}
+          {{- . | nindent 10 }}
+          {{- end }}
           {{- if .Values.vector.resources }}
           resources:
           {{- toYaml .Values.vector.resources | nindent 12 }}

--- a/charts/self-hosted/values.schema.json
+++ b/charts/self-hosted/values.schema.json
@@ -22,14 +22,6 @@
           "type": "string",
           "enum": ["soft", "hard", "none"]
         },
-        "securityContext": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "runAsNonRoot": { "type": "boolean" }
-          },
-          "required": ["enabled", "runAsNonRoot"]
-        },
         "settings": {
           "type": "object",
           "properties": {
@@ -49,6 +41,7 @@
       "type": "object",
       "properties": {
         "fullnameOverride": { "type": "string" },
+        "securityContext": { "$ref": "#/definitions/securityContext" },
         "replicas": { "type": "integer", "minimum": 0 },
         "image": { "$ref": "#/definitions/image" },
         "identifyImage": { "$ref": "#/definitions/image" },
@@ -92,6 +85,7 @@
       "type": "object",
       "properties": {
         "fullnameOverride": { "type": "string" },
+        "securityContext": { "$ref": "#/definitions/securityContext" },
         "replicas": { "type": "integer", "minimum": 0 },
         "image": { "$ref": "#/definitions/image" },
         "sinks": {
@@ -138,6 +132,7 @@
           "type": "object",
           "properties": {
             "fullnameOverride": { "type": "string" },
+            "securityContext": { "$ref": "#/definitions/securityContext" },
             "replicas": { "type": "integer", "minimum": 0 },
             "image": { "$ref": "#/definitions/image" },
             "persistence": { "$ref": "#/definitions/persistence" },
@@ -161,6 +156,7 @@
           "type": "object",
           "properties": {
             "fullnameOverride": { "type": "string" },
+            "securityContext": { "$ref": "#/definitions/securityContext" },
             "image": { "$ref": "#/definitions/image" },
             "username": { "type": "string" },
             "password": { "type": "string" },
@@ -178,8 +174,9 @@
           "type": "object",
           "properties": {
             "fullnameOverride": { "type": "string" },
+            "securityContext": { "$ref": "#/definitions/securityContext" },
             "image": { "$ref": "#/definitions/image" },
-            "persistence": { "$ref": "#/definitions/persistence" },
+            "persistence": { "$ref": "#/definitions/redisPersistence" },
             "resources": { "$ref": "#/definitions/resources" },
             "customLabels": { "type": "object" },
             "customAnnotations": { "type": "object" },
@@ -193,6 +190,7 @@
           "type": "object",
           "properties": {
             "fullnameOverride": { "type": "string" },
+            "securityContext": { "$ref": "#/definitions/securityContext" },
             "image": { "$ref": "#/definitions/image" },
             "username": { "type": "string" },
             "password": { "type": "string" },
@@ -210,6 +208,7 @@
           "type": "object",
           "properties": {
             "fullnameOverride": { "type": "string" },
+            "securityContext": { "$ref": "#/definitions/securityContext" },
             "image": { "$ref": "#/definitions/image" },
             "mcImage": { "$ref": "#/definitions/image" },
             "accessKey": { "type": "string" },
@@ -295,6 +294,36 @@
         "requests": { "type": "object" }
       }
     },
+    "securityContext": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false }
+      },
+      "required": ["enabled"]
+    },
+    "redisPersistence": {
+      "type": "object",
+      "properties": {
+        "storageClass": { "type": "string" },
+        "storageSize": {
+          "type": "string",
+          "pattern": "^[0-9]+(Gi|Mi|Ti)$"
+        },
+        "existingClaim": { "type": "string" },
+        "aof": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "appendFsync": {
+              "type": "string",
+              "enum": ["always", "everysec", "no"],
+              "default": "everysec"
+            }
+          },
+          "required": ["enabled", "appendFsync"]
+        }
+      }
+    },
     "persistence": {
       "type": "object",
       "properties": {
@@ -311,6 +340,7 @@
       "type": "object",
       "properties": {
         "fullnameOverride": { "type": "string" },
+        "securityContext": { "$ref": "#/definitions/securityContext" },
         "replicas": { "type": "integer", "minimum": 0 },
         "image": { "$ref": "#/definitions/image" },
         "customLabels": { "type": "object" },

--- a/charts/self-hosted/values.schema.json
+++ b/charts/self-hosted/values.schema.json
@@ -22,6 +22,14 @@
           "type": "string",
           "enum": ["soft", "hard", "none"]
         },
+        "securityContext": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "runAsNonRoot": { "type": "boolean" }
+          },
+          "required": ["enabled", "runAsNonRoot"]
+        },
         "settings": {
           "type": "object",
           "properties": {

--- a/charts/self-hosted/values.yaml
+++ b/charts/self-hosted/values.yaml
@@ -12,6 +12,17 @@ global:
   # We use Topology Spread Constraints to achieve pod distribution across nodes.
   podAntiAffinityPreset: "soft" # soft, hard, or none
 
+  # ── Pod & Container Security Context ────────────────────────
+  # Baseline hardening (enabled by default):
+  #   Pod-level:        seccompProfile RuntimeDefault
+  #   Container-level:  allowPrivilegeEscalation=false, capabilities drop ALL
+  # Non-root UIDs/GIDs are selected per workload to match the bundled images.
+  # Disable only as a temporary compatibility escape hatch for custom images or
+  # storage drivers that cannot apply fsGroup ownership to mounted volumes.
+  securityContext:
+    enabled: true
+    runAsNonRoot: true
+
   # Global application settings
   settings:
     # The public URL through which users access the application.

--- a/charts/self-hosted/values.yaml
+++ b/charts/self-hosted/values.yaml
@@ -240,11 +240,11 @@ dependencies:
       # Kubernetes image pull policy (Always, IfNotPresent, Never).
       pullPolicy: "IfNotPresent"
     persistence: # Persistent Storage Configuration
-      storageClass: ""
-      storageSize: "10Gi"
       aof:
         enabled: false
         appendFsync: everysec
+      storageClass: ""
+      storageSize: "10Gi"
       # Use an existing PVC by name (leave empty to create a new one)
       existingClaim: ""
     customLabels: {}

--- a/charts/self-hosted/values.yaml
+++ b/charts/self-hosted/values.yaml
@@ -1,55 +1,36 @@
 nameOverride: ""
 fullnameOverride: ""
-
 global:
   # Image pull settings
   imagePullSecrets: []
-
   # Kubernetes cluster domain name
   clusterDomain: cluster.local
-
   # Kubernetes Pod Affinity/Anti-Affinity settings
   # We use Topology Spread Constraints to achieve pod distribution across nodes.
   podAntiAffinityPreset: "soft" # soft, hard, or none
-
-  # ── Pod & Container Security Context ────────────────────────
-  # Baseline hardening (enabled by default):
-  #   Pod-level:        seccompProfile RuntimeDefault
-  #   Container-level:  allowPrivilegeEscalation=false, capabilities drop ALL
-  # Non-root UIDs/GIDs are selected per workload to match the bundled images.
-  # Disable only as a temporary compatibility escape hatch for custom images or
-  # storage drivers that cannot apply fsGroup ownership to mounted volumes.
-  securityContext:
-    enabled: true
-    runAsNonRoot: true
-
   # Global application settings
   settings:
     # The public URL through which users access the application.
     # If you use SSO features, this is recommended to be set to the external URL of your gateway (e.g., https://app.example.com).
     host: ""
-
     # Global resource limits (apply across all modules)
     # These are safety guardrails to prevent excessive resource usage
     limits:
       # Maximum number of metrics/charts allowed per single copy operation
       maxMetricsPerCopy: 20000
-
 gateway:
   fullnameOverride: ""
-
+  securityContext:
+    enabled: false
   replicas: 2
-
   image:
     repository: repo.swanlab.cn/public/traefik
     tag: "3.6"
     pullPolicy: "IfNotPresent"
-
   identifyImage:
     repository: repo.swanlab.cn/public/swanlab-helper/identify
     tag: "v1.2"
     pullPolicy: "IfNotPresent"
-
   # Service configuration
   service:
     type: ClusterIP
@@ -62,7 +43,6 @@ gateway:
       traefik: 8081
       # Port for Prometheus metrics.
       metrics: 9100
-
   customLabels: {}
   customAnnotations: {}
   customPodLabels: {}
@@ -70,19 +50,18 @@ gateway:
   customTolerations: []
   customNodeSelector: {}
   resources: {}
-
 vector:
   fullnameOverride: ""
+  securityContext:
+    enabled: false
   replicas: 2
   image:
     repository: repo.swanlab.cn/public/vector
     tag: "0.51.1-debian"
     pullPolicy: "IfNotPresent"
-
   sinks:
     # Ensure bufferMaxSize is smaller than persistence.storageSize / 3.
-    bufferMaxSize: 10737418240  # 10Gi
-
+    bufferMaxSize: 10737418240 # 10Gi
   customLabels: {}
   customAnnotations: {}
   customPodLabels: {}
@@ -90,40 +69,35 @@ vector:
   customTolerations: []
   customNodeSelector: {}
   resources: {}
-
   persistence:
     storageClass: ""
     # At least 60Gi is recommended for Vector to store logs.
     # Ensure storageSize is at least 3 times the bufferMaxSize.
     storageSize: "40Gi"
-
   # Dedicated headless Service for metrics scraping (does not affect business traffic on the main Service)
   #   true  = create a <fullname>-monitor headless Service so Prometheus dns_sd can discover all Pod IPs
   #   false = do not create it (discover Pods yourself via kubernetes_sd_configs or other means)
   monitor:
     enable: false
-
-
 # Configuration for test image used in various components
 helper: # Test Image Configuration
   image:
     repository: repo.swanlab.cn/public/busybox
     tag: "1.37.0"
     pullPolicy: "IfNotPresent"
-
 # Configuration of main application services
 service:
   # Configuration of our main server service
   server:
     fullnameOverride: ""
+    securityContext:
+      enabled: false
     replicas: 2
-
     image:
       repository: repo.swanlab.cn/self-hosted/swanlab-server
       # For patch update delivery
       tag: ""
       pullPolicy: "IfNotPresent"
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -136,18 +110,17 @@ service:
     #   false = do not create it (discover Pods yourself via kubernetes_sd_configs or other means)
     monitor:
       enable: false
-
   # Configuration of our auth service
   auth:
     fullnameOverride: ""
+    securityContext:
+      enabled: false
     replicas: 2
-
     image:
       repository: repo.swanlab.cn/self-hosted/swanlab-auth
       # For patch update delivery
       tag: ""
       pullPolicy: "IfNotPresent"
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -155,19 +128,17 @@ service:
     customTolerations: []
     customNodeSelector: {}
     resources: {}
-
   # Configuration of our data collection services
   house:
     fullnameOverride: ""
+    securityContext:
+      enabled: false
     replicas: 2
-
     image:
       repository: repo.swanlab.cn/self-hosted/swanlab-house
       # For patch update delivery
       tag: ""
       pullPolicy: "IfNotPresent"
-
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -185,19 +156,17 @@ service:
     #   false = do not create it (discover Pods yourself via kubernetes_sd_configs or other means)
     monitor:
       enable: false
-
   # Configuration of our frontend service
   cloud:
     fullnameOverride: ""
+    securityContext:
+      enabled: false
     replicas: 1
-
     image:
       repository: repo.swanlab.cn/self-hosted/swanlab-cloud
       # For patch update delivery
       tag: ""
       pullPolicy: "IfNotPresent"
-
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -205,19 +174,17 @@ service:
     customTolerations: []
     customNodeSelector: {}
     resources: {}
-
   # Configuration of our frontend service
   next:
     fullnameOverride: ""
+    securityContext:
+      enabled: false
     replicas: 2
-
     image:
       repository: repo.swanlab.cn/self-hosted/swanlab-next
       # For patch update delivery
       tag: ""
       pullPolicy: "IfNotPresent"
-
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -225,15 +192,14 @@ service:
     customTolerations: []
     customNodeSelector: {}
     resources: {}
-
 # Configuration for internal-deployed infrastructure (Chart-managed services).
 # These components serve as the default application dependencies and are only
 # provisioned in the cluster if the corresponding 'integrations.<service>.enabled' is false.
 dependencies:
-
   postgres: # PostgreSQL Database Configuration
     fullnameOverride: ""
-
+    securityContext:
+      enabled: false
     image: # Image Configuration
       # Full image repository path (e.g., ghcr.io/cloudnative-pg/postgresql)
       repository: repo.swanlab.cn/self-hosted/postgres
@@ -241,19 +207,15 @@ dependencies:
       tag: "16.1"
       # Kubernetes image pull policy (Always, IfNotPresent, Never).
       pullPolicy: "IfNotPresent"
-
     username: ""
     password: ""
-
     persistence: # Persistent Storage Configuration
       # Kubernetes StorageClass to use for dynamic provisioning.
       storageClass: ""
       # Volume size for the database data.
       storageSize: "10Gi"
-
       # Use an existing PVC by name (leave empty to create a new one)
       existingClaim: ""
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -266,10 +228,10 @@ dependencies:
     #   Only takes effect when not using an external managed instance (integrations.postgres.enabled = false)
     monitor:
       enable: false
-
   redis: # Redis Configuration
     fullnameOverride: ""
-
+    securityContext:
+      enabled: false
     image: # Image Configuration
       # Full image repository path (e.g., redis/redis-stack)
       repository: repo.swanlab.cn/self-hosted/redis-stack
@@ -277,14 +239,14 @@ dependencies:
       tag: "7.4.0-v8"
       # Kubernetes image pull policy (Always, IfNotPresent, Never).
       pullPolicy: "IfNotPresent"
-
     persistence: # Persistent Storage Configuration
       storageClass: ""
       storageSize: "10Gi"
-
+      aof:
+        enabled: false
+        appendFsync: everysec
       # Use an existing PVC by name (leave empty to create a new one)
       existingClaim: ""
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -297,29 +259,25 @@ dependencies:
     #   Only takes effect when not using an external managed instance (integrations.redis.enabled = false)
     monitor:
       enable: false
-
   clickhouse: # ClickHouse Configuration
     fullnameOverride: ""
-
+    securityContext:
+      enabled: false
     image: # Image Configuration
       # Full image repository path (e.g., clickhouse/clickhouse-server)
       repository: repo.swanlab.cn/self-hosted/clickhouse-server
       # Image tag/version to use.
       tag: "24.3"
       pullPolicy: "IfNotPresent"
-
     # Authentication credentials.
     # Leave empty if using existingSecret.
     username: ""
     password: ""
-
     persistence: # Persistent Storage Configuration
       storageClass: ""
       storageSize: "20Gi"
-
       # Use an existing PVC by name (leave empty to create a new one)
       existingClaim: ""
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -333,35 +291,30 @@ dependencies:
     #   Only takes effect when not using an external managed instance (integrations.clickhouse.enabled = false)
     monitor:
       enable: false
-
   s3: # MinIO Object Storage Service
     fullnameOverride: ""
-
+    securityContext:
+      enabled: false
     image: # Image Configuration
       # Full image repository path (e.g., minio/minio)
       repository: repo.swanlab.cn/self-hosted/minio/minio
       # Image tag/version to use.
       tag: "RELEASE.2025-09-07T16-13-09Z"
       pullPolicy: "IfNotPresent"
-
     mcImage: # MinIO Client Image Configuration
       # Full image repository path (e.g., minio/mc)
       repository: repo.swanlab.cn/self-hosted/minio/mc
       # Image tag/version to use.
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: "IfNotPresent"
-
     accessKey: ""
     # If left empty, a secure secret key will be generated.
     secretKey: ""
-
     persistence: # Persistent Storage Configuration
       storageClass: ""
       storageSize: "20Gi"
-
       # Use an existing PVC by name (leave empty to create a new one)
       existingClaim: ""
-
     customLabels: {}
     customAnnotations: {}
     customPodLabels: {}
@@ -369,8 +322,6 @@ dependencies:
     customTolerations: []
     customNodeSelector: {}
     resources: {}
-
-
 # Configuration of external-deployed infrastructure
 integrations:
   postgres:
@@ -389,7 +340,6 @@ integrations:
     # | primaryUrl            |
     # | replicaUrl            |
     existingSecret: ""
-
   redis:
     # Enable to use an external Redis service.
     enabled: false
@@ -403,7 +353,6 @@ integrations:
     # |:----------------------|
     # | url                   |
     existingSecret: ""
-
   clickhouse:
     # Enable to use an external ClickHouse server.
     enabled: false
@@ -419,7 +368,6 @@ integrations:
     # | username              |
     # | password              |
     existingSecret: ""
-
   s3:
     # Enable to use an external S3-compatible object storage.
     enabled: false


### PR DESCRIPTION
## 概述

为所有 SwanLab 服务和内置依赖引入按服务开启的非 root 安全加固（`securityContext.enabled`，默认 `false`），并为 Redis 增加可选的 AOF 持久化。默认部署不受影响。

## 改动内容

- **SecurityContext**：每个服务/依赖新增 `securityContext.enabled`。开启后 pod 级设置 `runAsNonRoot` + `runAsUser/Group` + `fsGroup`（`OnRootMismatch`）+ `seccompProfile`，容器级 drop 全部 capability 且 `allowPrivilegeEscalation: false`。
- **数据卷属主修正**（`init-volume-permissions`，root initContainer），覆盖 postgres/redis/clickhouse/minio/vector：逐文件检查、仅 chown 不匹配项，用于修正加固前写入的 root 属主数据，以及 fsGroup 失效的 CSI 环境。因其以 root 运行，与 restricted PodSecurityStandard 不兼容，此类集群请保持 `securityContext.enabled=false`。网络文件系统（NFS/NAS/CPFS）上全量遍历较慢，块存储（ESSD/EBS/PD）无此问题。
- **非 root 绑定特权端口**：gateway（traefik）与 cloud（nginx）通过安全 sysctl `net.ipv4.ip_unprivileged_port_start=80` 绑定 80 端口，替代 NET_BIND_SERVICE capability（在 containerd 下经 shell entrypoint exec 后会丢失）。要求节点内核 >= 4.11。
- **Redis AOF**：可选 `dependencies.redis.persistence.aof`（通过 `REDIS_ARGS` 下发 `--appendonly yes --appendfsync ...`）。
- 非 root 运行适配：mc init job 与 swanlab-server 的 `HOME` 重定向、swanlab-cloud 的 nginx 缓存/pid 可写目录、swanlab-house 通过 initContainer 将 `/app/playground` 拷入可写 emptyDir。

## 兼容性

- **默认 values**（所有 `securityContext` 关闭）渲染结果与上一发布版**逐字节一致**，存量用户零影响。
- **外接依赖**（`integrations.*.enabled=true`）同样逐字节一致：内置依赖 pod 与 initContainer 完全不渲染。
- 已有 root 属主数据的卷开启加固时，由 initContainer 在首次启动自动修正。
- 已有实例开启 Redis AOF，必须**先**在运行中的 pod 执行 `CONFIG SET appendonly yes` 再升级，否则新 pod 会从空 AOF 启动、忽略 RDB。
- 回滚无感（pod 恢复 root 运行，可正常读写加固后的卷），唯一例外：开启过 AOF 的实例，回滚到不支持 AOF 的版本前必须先 `BGSAVE`，否则最近一次 RDB 快照之后的数据会丢失。

注意：升级后所有 pod 会重启。
